### PR TITLE
Support for expansion files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Usage
     google-play-publisher \
       --auth api.json \
       --recent-changes "en-US=`cat changes.txt`" \
-      /path/to/Package.apk
+      /path/to/Package.apk \
+      /path/to/Expansion.obb \  # optional
+      /path/to/Expansion2.obb   # optional
 
 ### Other options
 
@@ -52,6 +54,9 @@ var changes = fs.readFileSync('changes.txt')
 // track can be alpha, beta, production or rollout
 publisher.upload('/path/to/apk', {
   track: 'beta', // default alpha
+  obbs: [  // optional expansion files (max 2)
+    '/path/to/somefile.obb'
+  ],
   recentChanges: {
     'en-US': changes
   },

--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,8 @@ var assert = require('assert')
 
 var authJSON = JSON.parse(fs.readFileSync(argv.auth)) // assume a JSON
 var options = {
-  track: argv.track
+  track: argv.track,
+  obbs: argv._.slice(1)
 }
 
 if (argv.recentChanges) {


### PR DESCRIPTION
Also fixed all error situations where a lot of "varname of undefined" errors were thrown.
Support for OBB files also added to the CLI, and documented in the Readme.

Output:

```
$ DEBUG=google-play-publisher ~/Projects/google-play-publisher/cli.js -t alpha -a ./android.json Build/Android/Unity-Android.apk Build/Android/Unity-Android.main.obb 
  google-play-publisher Detected package name REDACTED +0ms
  google-play-publisher Detected version code 5 +3ms
  google-play-publisher > Authenticating +4ms
  google-play-publisher > Authenticated succesfully +710ms
  google-play-publisher > Creating edit +0ms
  google-play-publisher > Created edit with id 2885174362854013500 +899ms
  google-play-publisher > Uploading release +1ms
  google-play-publisher > Uploaded Build/Android/Unity-Android.apk with version code 5 and SHA1 09fda6834edeac19be8b2d3aeae1b13283692cca +7s
  google-play-publisher > Uploading 1 expansion file(s) +1ms
  google-play-publisher > Uploaded Build/Android/Unity-Android.main.obb +7s
  google-play-publisher > Assigning APK to alpha track +0ms
  google-play-publisher > Assigned APK to alpha track +876ms
  google-play-publisher > Commiting changes +1ms
  google-play-publisher > Commited changes +6s
  google-play-publisher > Finished uploading APK +0ms
```

Closes #7
Fixes #8